### PR TITLE
strip folder when id linking

### DIFF
--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -2070,7 +2070,7 @@ and rewrite link paths to make blogging more seamless."
            (let ((path (progn
                          ;; Treat links to `file.org' as links to `file.md'.
                          (if (string= ".org" (downcase (file-name-extension destination ".")))
-                             (concat (file-name-sans-extension destination) ".md")
+                             (concat (file-name-sans-extension (file-name-nondirectory destination)) ".md")
                            destination))))
              (if desc
                  (format "[%s]({{<relref \"%s\" >}})" desc path)


### PR DESCRIPTION
Adds (file-name-nondirectory) to the code computing the destination when exporting an id link,
to be consistent with the behaviour when exporting file links

It seems like both keeping the folder around (giving the option of using it to create a tree structure on the hugo site) and deleting it are defensible choices, but it seems like a mistake to have different behaviour in each case. For me, deleting the folder is the most useful behaviour, and it's also the standard behaviour of ox-hugo on file links, so it seems like the correct thing to reproduce.